### PR TITLE
Allow configuring User-Agent via config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ One should somehow get an API access key and set it as environment variable `HH_
 hh-responder uses [vacancies API](https://github.com/hhru/api/blob/master/docs_eng/vacancies.md#search) for searching based query parameters passed in a configuration file
 For the example of the config file please see here - [hh-responder-example.yaml](hh-responder-example.yaml)
 
+You can optionally override the default HTTP User-Agent header sent to hh.ru by setting the `user-agent` field in the configuration file.
+
 Then one can run the CLI. For example on Linux:
 ```
 HH_TOKEN=$(cat ~/hh_token.txt) ./hh-responder run --config ./hh-responder-example.yaml

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ const (
 type Config struct {
 	Search      *headhunter.SearchParams `mapstructure:"search"`
 	ExcludeFile string                   `mapstructure:"exclude-file"`
+	UserAgent   string                   `mapstructure:"user-agent"`
 	Apply       *struct {
 		Resume  string
 		Message string

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -76,6 +76,10 @@ func run(cmd *cobra.Command) {
 
 	hh := headhunter.New(ctx, logger, os.Getenv(hhTokenEnvVar))
 
+	if config != nil && config.UserAgent != "" {
+		hh.UserAgent = config.UserAgent
+	}
+
 	logger.Info("starting the search", zap.String("search", config.Search.Text))
 
 	vacancies, err := getVacancies(hh, config, cmd, logger)

--- a/hh-responder-example.yaml
+++ b/hh-responder-example.yaml
@@ -28,6 +28,10 @@ apply:
     Здравствуйте! Это сопроводительное письмо для вашей вакансии. Отклик сделан на публичное api HH.ru
     "
   exclude:
-    employers: 
+    employers:
       # Test employer
       - 3331116
+
+# Optional custom user-agent header to send with requests to hh.ru API.
+# Defaults to the built-in hh-responder identifier when omitted.
+user-agent: "spigell/hh-responder (spigelly@gmail.com)"


### PR DESCRIPTION
## Summary
- allow overriding the hh.ru client User-Agent value through the configuration file
- document the new configuration option and update the example config

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d17d8c96bc832f81481e0c9c2805db