### PR TITLE
Require HeadHunter token to be loaded from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ go build -ldflags="-X 'hh-responder/cmd.version=v1.0.1'"
 
 ## Usage
 
-One should somehow get an API access key and add it to the configuration file under the `token` setting before using the tool. Please read (Oauth docs)[https://api.hh.ru/openapi/en/redoc) for more information.
+One should somehow get an API access key, store it in a file, and point hh-responder to that file via the `token-file` configuration setting or the `HH_TOKEN_FILE` environment variable before using the tool. Storing the token directly in the configuration or other environment variables is not supported. Please read (Oauth docs)[https://api.hh.ru/openapi/en/redoc) for more information.
 
 hh-responder uses [vacancies API](https://github.com/hhru/api/blob/master/docs_eng/vacancies.md#search) for searching based query parameters passed in a configuration file
 For the example of the config file please see here - [hh-responder-example.yaml](hh-responder-example.yaml)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,7 @@ type Config struct {
 	Search      *headhunter.SearchParams `mapstructure:"search"`
 	ExcludeFile string                   `mapstructure:"exclude-file"`
 	UserAgent   string                   `mapstructure:"user-agent"`
-	Token       string                   `mapstructure:"token"`
+	TokenFile   string                   `mapstructure:"token-file"`
 	Apply       *struct {
 		Resume  string
 		Message string
@@ -43,6 +43,10 @@ func Execute() error {
 }
 
 func init() {
+	if err := viper.BindEnv("token-file", "HH_TOKEN_FILE"); err != nil {
+		log.Fatalf("binding HH_TOKEN_FILE environment variable: %v", err)
+	}
+
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "a config file (default is hh-responder.yaml in current directory)")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/spigell/hh-responder/internal/headhunter"
@@ -77,11 +78,16 @@ func run(cmd *cobra.Command) {
 		logger.Fatal("config is required")
 	}
 
-	if config.Token == "" {
-		logger.Fatal("headhunter token is missing", zap.String("hint", "set token in configuration file under 'token' key"))
+	token, err := resolveToken(config)
+	if err != nil {
+		logger.Fatal(
+			"loading headhunter token",
+			zap.Error(err),
+			zap.String("hint", "set HH_TOKEN_FILE environment variable or the 'token-file' key in the configuration file"),
+		)
 	}
 
-	hh := headhunter.New(ctx, logger, config.Token)
+	hh := headhunter.New(ctx, logger, token)
 
 	if config != nil && config.UserAgent != "" {
 		hh.UserAgent = config.UserAgent
@@ -143,6 +149,33 @@ func handleAction(action string, hh *headhunter.Client, logger *zap.Logger, conf
 	default:
 		return fmt.Errorf("invalid action: %s", action)
 	}
+}
+
+func resolveToken(config *Config) (string, error) {
+	if config == nil {
+		return "", errors.New("config is required")
+	}
+
+	tokenFile := strings.TrimSpace(config.TokenFile)
+	if tokenFile == "" {
+		tokenFile = strings.TrimSpace(viper.GetString("token-file"))
+	}
+
+	if tokenFile == "" {
+		return "", errors.New("headhunter token file is not configured")
+	}
+
+	tokenBytes, err := os.ReadFile(tokenFile)
+	if err != nil {
+		return "", fmt.Errorf("reading token file %q: %w", tokenFile, err)
+	}
+
+	token := strings.TrimSpace(string(tokenBytes))
+	if token == "" {
+		return "", fmt.Errorf("token file %q is empty", tokenFile)
+	}
+
+	return token, nil
 }
 
 func manualApply(hh *headhunter.Client, logger *zap.Logger, config *Config, vacancies *headhunter.Vacancies) error {

--- a/hh-responder-example.yaml
+++ b/hh-responder-example.yaml
@@ -1,6 +1,7 @@
 # Documentation for search api - https://github.com/hhru/api/blob/master/docs_eng/vacancies.md
-# Personal access token used for authenticated requests to hh.ru API.
-token: "put-your-token-here"
+# Path to a file that contains the personal access token used for authenticated requests to hh.ru API.
+# Provide it via the HH_TOKEN_FILE environment variable or uncomment the line below.
+# token-file: /path/to/token
 
 search:
   clusters: false


### PR DESCRIPTION
## Summary
- remove the raw token configuration and environment variable binding in favor of the token file path
- require `resolveToken` to read exclusively from the configured file and surface clearer errors when the path is missing or empty
- document that only the file-based token workflow is supported going forward

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d40b2b86b4832fa27cad49bf13a87f