### PR TITLE
Refactor Gemini matching to use chat API

### DIFF
--- a/internal/ai/gemini/client_test.go
+++ b/internal/ai/gemini/client_test.go
@@ -12,42 +12,60 @@ import (
 	"google.golang.org/genai"
 )
 
-type fakeModels struct {
+type fakeChatCreator struct {
 	mu    sync.Mutex
-	calls []callRecord
-	queue map[string][]fakeResponse
+	calls []chatCallRecord
+	queue map[string][]fakeChatResponse
 }
 
-type fakeResponse struct {
+type chatCallRecord struct {
+	model  string
+	config *genai.GenerateContentConfig
+	chat   *fakeChat
+}
+
+type fakeChatResponse struct {
 	resp *genai.GenerateContentResponse
 	err  error
 }
 
-type callRecord struct {
-	model string
+type fakeChat struct {
+	mu       sync.Mutex
+	response fakeChatResponse
+	messages []string
 }
 
-func newFakeModels() *fakeModels {
-	return &fakeModels{queue: make(map[string][]fakeResponse)}
-}
-
-func (f *fakeModels) enqueue(model string, resp *genai.GenerateContentResponse, err error) {
+func (f *fakeChat) SendMessage(ctx context.Context, parts ...genai.Part) (*genai.GenerateContentResponse, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.queue[model] = append(f.queue[model], fakeResponse{resp: resp, err: err})
+	for _, part := range parts {
+		f.messages = append(f.messages, part.Text)
+	}
+	return f.response.resp, f.response.err
 }
 
-func (f *fakeModels) GenerateContent(ctx context.Context, model string, contents []*genai.Content, config *genai.GenerateContentConfig) (*genai.GenerateContentResponse, error) {
+func newFakeChatCreator() *fakeChatCreator {
+	return &fakeChatCreator{queue: make(map[string][]fakeChatResponse)}
+}
+
+func (f *fakeChatCreator) enqueue(model string, resp *genai.GenerateContentResponse, err error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.calls = append(f.calls, callRecord{model: model})
+	f.queue[model] = append(f.queue[model], fakeChatResponse{resp: resp, err: err})
+}
+
+func (f *fakeChatCreator) Create(ctx context.Context, model string, config *genai.GenerateContentConfig, history []*genai.Content) (chatSession, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	responses := f.queue[model]
 	if len(responses) == 0 {
 		return nil, errors.New("unexpected call")
 	}
 	res := responses[0]
 	f.queue[model] = responses[1:]
-	return res.resp, res.err
+	chat := &fakeChat{response: res}
+	f.calls = append(f.calls, chatCallRecord{model: model, config: config, chat: chat})
+	return chat, nil
 }
 
 func TestGeneratorRetriesOnTemporaryError(t *testing.T) {
@@ -55,23 +73,23 @@ func TestGeneratorRetriesOnTemporaryError(t *testing.T) {
 	sleep = func(time.Duration) {}
 	defer func() { sleep = originalSleep }()
 
-	models := newFakeModels()
+	chats := newFakeChatCreator()
 	tempErr := genai.APIError{Code: http.StatusInternalServerError, Status: "INTERNAL"}
-	models.enqueue("gemini-pro", nil, tempErr)
-	models.enqueue("gemini-pro", &genai.GenerateContentResponse{
+	chats.enqueue("gemini-pro", nil, tempErr)
+	chats.enqueue("gemini-pro", &genai.GenerateContentResponse{
 		Candidates: []*genai.Candidate{{
 			Content: &genai.Content{Parts: []*genai.Part{{Text: "retry ok"}}},
 		}},
 	}, nil)
 
 	g := &Generator{
-		models:     models,
+		chats:      chats,
 		model:      "gemini-pro",
 		maxRetries: 2,
 		logger:     zap.NewNop(),
 	}
 
-	output, err := g.GenerateContent(context.Background(), " say hi ")
+	output, err := g.GenerateContent(context.Background(), "system", "message")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -80,8 +98,20 @@ func TestGeneratorRetriesOnTemporaryError(t *testing.T) {
 		t.Fatalf("unexpected output: %q", output)
 	}
 
-	if len(models.calls) != 2 {
-		t.Fatalf("expected 2 calls, got %d", len(models.calls))
+	if len(chats.calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d", len(chats.calls))
+	}
+
+	for _, call := range chats.calls {
+		if call.config == nil || call.config.SystemInstruction == nil {
+			t.Fatalf("expected system instruction to be set")
+		}
+		if got := call.config.SystemInstruction.Parts[0].Text; got != "system" {
+			t.Fatalf("unexpected system instruction: %q", got)
+		}
+		if len(call.chat.messages) != 1 || call.chat.messages[0] != "message" {
+			t.Fatalf("unexpected chat message: %+v", call.chat.messages)
+		}
 	}
 }
 
@@ -90,50 +120,50 @@ func TestGeneratorStopsAfterRetriesExhausted(t *testing.T) {
 	sleep = func(time.Duration) {}
 	defer func() { sleep = originalSleep }()
 
-	models := newFakeModels()
+	chats := newFakeChatCreator()
 	tempErr := genai.APIError{Code: http.StatusInternalServerError, Status: "INTERNAL"}
-	models.enqueue("gemini-pro", nil, tempErr)
-	models.enqueue("gemini-pro", nil, tempErr)
+	chats.enqueue("gemini-pro", nil, tempErr)
+	chats.enqueue("gemini-pro", nil, tempErr)
 
 	g := &Generator{
-		models:     models,
+		chats:      chats,
 		model:      "gemini-pro",
 		maxRetries: 2,
 		logger:     zap.NewNop(),
 	}
 
-	_, err := g.GenerateContent(context.Background(), " say hi ")
+	_, err := g.GenerateContent(context.Background(), "sys", "msg")
 	if err == nil {
 		t.Fatal("expected error after retries exhausted")
 	}
 
-	if len(models.calls) != 2 {
-		t.Fatalf("expected 2 calls, got %d", len(models.calls))
+	if len(chats.calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d", len(chats.calls))
 	}
 }
 
 func TestGeneratorDoesNotRetryOnLongQuotaDelay(t *testing.T) {
-	models := newFakeModels()
+	chats := newFakeChatCreator()
 	quotaErr := genai.APIError{
 		Code:    http.StatusTooManyRequests,
 		Status:  "RESOURCE_EXHAUSTED",
 		Message: "quota exhausted, retry after 60 seconds",
 	}
-	models.enqueue("gemini-pro", nil, quotaErr)
+	chats.enqueue("gemini-pro", nil, quotaErr)
 
 	g := &Generator{
-		models:     models,
+		chats:      chats,
 		model:      "gemini-pro",
 		maxRetries: 3,
 		logger:     zap.NewNop(),
 	}
 
-	_, err := g.GenerateContent(context.Background(), " say hi ")
+	_, err := g.GenerateContent(context.Background(), "sys", "msg")
 	if err == nil {
 		t.Fatal("expected error when quota delay too long")
 	}
 
-	if len(models.calls) != 1 {
-		t.Fatalf("expected single call, got %d", len(models.calls))
+	if len(chats.calls) != 1 {
+		t.Fatalf("expected single call, got %d", len(chats.calls))
 	}
 }

--- a/internal/ai/gemini/matcher_test.go
+++ b/internal/ai/gemini/matcher_test.go
@@ -2,6 +2,7 @@ package gemini
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/spigell/hh-responder/internal/headhunter"
@@ -9,13 +10,15 @@ import (
 )
 
 type stubGenerator struct {
-	response   string
-	err        error
-	lastPrompt string
+	response    string
+	err         error
+	instruction string
+	message     string
 }
 
-func (s *stubGenerator) GenerateContent(ctx context.Context, prompt string) (string, error) {
-	s.lastPrompt = prompt
+func (s *stubGenerator) GenerateContent(ctx context.Context, systemInstruction, message string) (string, error) {
+	s.instruction = systemInstruction
+	s.message = message
 	if s.err != nil {
 		return "", s.err
 	}
@@ -50,8 +53,16 @@ func TestMatcherEvaluate(t *testing.T) {
 		t.Fatalf("expected reason to be populated")
 	}
 
-	if stub.lastPrompt == "" {
-		t.Fatalf("expected prompt to be sent")
+	if stub.instruction == "" || stub.message == "" {
+		t.Fatalf("expected system instruction and message to be sent")
+	}
+
+	if !strings.Contains(stub.instruction, "Resume") || !strings.Contains(stub.instruction, "skills") {
+		t.Fatalf("expected resume data in system instruction: %s", stub.instruction)
+	}
+
+	if !strings.Contains(stub.message, "Vacancy") || !strings.Contains(stub.message, "Go Developer") {
+		t.Fatalf("expected vacancy data in chat message: %s", stub.message)
 	}
 }
 


### PR DESCRIPTION
## Summary
- switch the Gemini generator to create chat sessions and send vacancies as chat messages with resume context in the system instruction
- update the matcher to build separate system instructions for the resume and message content for each vacancy
- refresh unit tests to cover the chat-based generator flow and ensure prompts contain the right data

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d66634d8d0832fbbe12ea0ffe8265b