### PR TITLE
refactor: generalize logger field helpers

### DIFF
--- a/internal/ai/gemini/matcher.go
+++ b/internal/ai/gemini/matcher.go
@@ -13,12 +13,14 @@ import (
 
 	"github.com/spigell/hh-responder/internal/ai"
 	"github.com/spigell/hh-responder/internal/headhunter"
+	logfields "github.com/spigell/hh-responder/internal/logger"
 	"github.com/spigell/hh-responder/internal/utils"
 	"go.uber.org/zap"
 )
 
 type contentGenerator interface {
 	GenerateContent(ctx context.Context, prompt string) (string, error)
+	Model() string
 }
 
 type Matcher struct {
@@ -37,6 +39,13 @@ func NewMatcher(generator contentGenerator, logger *zap.Logger, minScore float64
 	if maxLogLength <= 0 {
 		maxLogLength = defaultMaxLogLength
 	}
+
+	var model string
+	if generator != nil {
+		model = generator.Model()
+	}
+
+	logger = logfields.WithCommonFields(logger, "gemini", model)
 
 	return &Matcher{
 		generator: generator,

--- a/internal/ai/gemini/matcher_test.go
+++ b/internal/ai/gemini/matcher_test.go
@@ -22,6 +22,10 @@ func (s *stubGenerator) GenerateContent(ctx context.Context, prompt string) (str
 	return s.response, nil
 }
 
+func (s *stubGenerator) Model() string {
+	return "stub-model"
+}
+
 func TestMatcherEvaluate(t *testing.T) {
 	stub := &stubGenerator{response: `{"fit": true, "score": 0.9, "reason": "Matches skills", "message": "Hello"}`}
 	matcher := NewMatcher(stub, zap.NewNop(), 0.5, 0)

--- a/internal/logger/ai_fields.go
+++ b/internal/logger/ai_fields.go
@@ -1,0 +1,72 @@
+package logger
+
+import (
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+const (
+	// FieldProvider is the structured log field key for the AI provider name.
+	FieldProvider = "ai_provider"
+	// FieldModel is the structured log field key for the AI model identifier.
+	FieldModel = "ai_model"
+)
+
+// StringField describes a string-valued structured logging field.
+type StringField struct {
+	Key   string
+	Value string
+}
+
+// StringFields converts the provided key/value pairs into zap fields, trimming
+// whitespace and omitting entries with empty keys or values.
+func StringFields(fields ...StringField) []zap.Field {
+	result := make([]zap.Field, 0, len(fields))
+	for _, field := range fields {
+		key := strings.TrimSpace(field.Key)
+		if key == "" {
+			continue
+		}
+
+		value := strings.TrimSpace(field.Value)
+		if value == "" {
+			continue
+		}
+
+		result = append(result, zap.String(key, value))
+	}
+
+	return result
+}
+
+// WithFields safely attaches the provided fields to the logger.
+// If the logger is nil or no fields are supplied, the input logger is returned
+// unchanged, defaulting to a no-op logger when nil.
+func WithFields(logger *zap.Logger, fields ...zap.Field) *zap.Logger {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	if len(fields) == 0 {
+		return logger
+	}
+
+	return logger.With(fields...)
+}
+
+// CommonFields returns standard zap fields that describe the AI provider and model.
+// Empty values are ignored to keep log entries compact when information is missing.
+func CommonFields(provider, model string) []zap.Field {
+	return StringFields(
+		StringField{Key: FieldProvider, Value: provider},
+		StringField{Key: FieldModel, Value: model},
+	)
+}
+
+// WithCommonFields attaches the common AI fields to the provided logger.
+// If the logger is nil, a no-op logger is created to avoid panics.
+func WithCommonFields(logger *zap.Logger, provider, model string) *zap.Logger {
+	fields := CommonFields(provider, model)
+	return WithFields(logger, fields...)
+}

--- a/internal/logger/ai_fields_test.go
+++ b/internal/logger/ai_fields_test.go
@@ -1,0 +1,106 @@
+package logger
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestStringFields(t *testing.T) {
+	fields := StringFields(
+		StringField{Key: "  provider  ", Value: "  Gemini  "},
+		StringField{Key: "ignored", Value: "   "},
+		StringField{Key: "   ", Value: "empty key"},
+	)
+
+	if len(fields) != 1 {
+		t.Fatalf("expected 1 field, got %d", len(fields))
+	}
+
+	if fields[0].Key != "provider" || fields[0].String != "Gemini" {
+		t.Fatalf("unexpected provider field: %+v", fields[0])
+	}
+
+	empty := StringFields()
+	if len(empty) != 0 {
+		t.Fatalf("expected empty fields, got %d", len(empty))
+	}
+}
+
+func TestWithFields(t *testing.T) {
+	core, observed := observer.New(zapcore.InfoLevel)
+	logger := zap.New(core)
+
+	enriched := WithFields(logger, zap.String("foo", "bar"))
+	enriched.Info("test log")
+
+	entries := observed.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	ctx := entries[0].ContextMap()
+	if ctx["foo"] != "bar" {
+		t.Fatalf("expected field to be bar, got %q", ctx["foo"])
+	}
+
+	enriched = WithFields(nil, zap.String("baz", "qux"))
+	if enriched == nil {
+		t.Fatalf("expected fallback logger when nil provided")
+	}
+
+	// Ensure logging with the fallback logger does not panic.
+	enriched.Info("another log")
+}
+
+func TestCommonFields(t *testing.T) {
+	fields := CommonFields("  Gemini  ", "model-v1")
+	if len(fields) != 2 {
+		t.Fatalf("expected 2 fields, got %d", len(fields))
+	}
+
+	if fields[0].Key != FieldProvider || fields[0].String != "Gemini" {
+		t.Fatalf("unexpected provider field: %+v", fields[0])
+	}
+
+	if fields[1].Key != FieldModel || fields[1].String != "model-v1" {
+		t.Fatalf("unexpected model field: %+v", fields[1])
+	}
+
+	empty := CommonFields("", "")
+	if len(empty) != 0 {
+		t.Fatalf("expected empty fields, got %d", len(empty))
+	}
+}
+
+func TestWithCommonFields(t *testing.T) {
+	core, observed := observer.New(zapcore.InfoLevel)
+	logger := zap.New(core)
+
+	enriched := WithCommonFields(logger, "gemini", "model-x")
+	enriched.Info("test log")
+
+	entries := observed.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	ctx := entries[0].ContextMap()
+	if ctx[FieldProvider] != "gemini" {
+		t.Fatalf("expected provider field to be gemini, got %q", ctx[FieldProvider])
+	}
+
+	if ctx[FieldModel] != "model-x" {
+		t.Fatalf("expected model field to be model-x, got %q", ctx[FieldModel])
+	}
+
+	enriched = WithCommonFields(nil, "gemini", "model-x")
+	if enriched == nil {
+		t.Fatalf("expected fallback logger when nil provided")
+	}
+
+	// Ensure logging with the fallback logger does not panic.
+	enriched.Info("another log")
+}


### PR DESCRIPTION
## Summary
- add generic string field helpers that trim empty keys/values before building zap fields
- provide a reusable logger wrapper that safely attaches fields and powers the AI helpers
- extend logger tests to cover the generic helpers alongside the existing AI-specific behavior

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d6b9ef7d5c832fbbeaf5ba07dbb92a