### PR TITLE
Refactor secret loading for tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Then one can run the CLI. For example on Linux:
 
 ## AI Assistance
 
-Set the `ai.enabled` flag in the configuration file to let hh-responder evaluate vacancies against the selected resume and generate tailored cover letters with Google's Gemini API. Supply the credentials either via the `ai.gemini.api-key` field or the `GEMINI_API_KEY` environment variable. You can tune the filtering aggressiveness with `ai.minimum-fit-score` (0 disables the score threshold) and control retry attempts on transient or short quota errors via `ai.gemini.max-retries`. See `hh-responder-example.yaml` for a complete example.
+Set the `ai.enabled` flag in the configuration file to let hh-responder evaluate vacancies against the selected resume and generate tailored cover letters with Google's Gemini API. Supply the credentials either via the `ai.gemini.api-key-file` field (or `GEMINI_API_KEY_FILE` environment variable) or inline with `ai.gemini.api-key` / `GEMINI_API_KEY`. You can tune the filtering aggressiveness with `ai.minimum-fit-score` (0 disables the score threshold) and control retry attempts on transient or short quota errors via `ai.gemini.max-retries`. See `hh-responder-example.yaml` for a complete example.
 
 ## To do list:
 - Add GH actions

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,7 @@ type AIConfig struct {
 
 type GeminiConfig struct {
 	APIKey       string `mapstructure:"api-key"`
+	APIKeyFile   string `mapstructure:"api-key-file"`
 	Model        string `mapstructure:"model"`
 	MaxRetries   int    `mapstructure:"max-retries"`
 	MaxLogLength int    `mapstructure:"max-log-length"`
@@ -60,6 +61,14 @@ func Execute() error {
 func init() {
 	if err := viper.BindEnv("token-file", "HH_TOKEN_FILE"); err != nil {
 		log.Fatalf("binding HH_TOKEN_FILE environment variable: %v", err)
+	}
+
+	if err := viper.BindEnv("ai.gemini.api-key", "GOOGLE_API_KEY", "GEMINI_API_KEY"); err != nil {
+		log.Fatalf("binding GEMINI_API_KEY environment variable: %v", err)
+	}
+
+	if err := viper.BindEnv("ai.gemini.api-key-file", "GOOGLE_API_KEY_FILE", "GEMINI_API_KEY_FILE"); err != nil {
+		log.Fatalf("binding GEMINI_API_KEY_FILE environment variable: %v", err)
 	}
 
 	cobra.OnInitialize(initConfig)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"os"
 	"strings"
 
 	"github.com/spigell/hh-responder/internal/ai"
@@ -14,6 +13,7 @@ import (
 	"github.com/spigell/hh-responder/internal/filtering"
 	"github.com/spigell/hh-responder/internal/headhunter"
 	"github.com/spigell/hh-responder/internal/logger"
+	"github.com/spigell/hh-responder/internal/secrets"
 
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
@@ -200,17 +200,10 @@ func resolveToken(config *Config) (string, error) {
 		return "", errors.New("headhunter token file is not configured")
 	}
 
-	tokenBytes, err := os.ReadFile(tokenFile)
-	if err != nil {
-		return "", fmt.Errorf("reading token file %q: %w", tokenFile, err)
-	}
-
-	token := strings.TrimSpace(string(tokenBytes))
-	if token == "" {
-		return "", fmt.Errorf("token file %q is empty", tokenFile)
-	}
-
-	return token, nil
+	return secrets.Load(secrets.Source{
+		Name: "headhunter token",
+		File: tokenFile,
+	})
 }
 
 func manualApply(hh *headhunter.Client, logger *zap.Logger, config *Config, vacancies *headhunter.Vacancies, resume *headhunter.Resume) error {
@@ -313,9 +306,13 @@ func newAIMatcher(ctx context.Context, cfg *AIConfig, logger *zap.Logger) (ai.Ma
 		return nil, fmt.Errorf("unsupported ai provider: %s", cfg.Provider)
 	}
 
-	apiKey := strings.TrimSpace(cfg.Gemini.APIKey)
-	if apiKey == "" {
-		return nil, fmt.Errorf("gemini api key is required (set ai.gemini.api-key or GOOGLE_API_KEY/GEMINI_API_KEY)")
+	apiKey, err := secrets.Load(secrets.Source{
+		Name:  "gemini api key",
+		Value: cfg.Gemini.APIKey,
+		File:  cfg.Gemini.APIKeyFile,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w (set ai.gemini.api-key, ai.gemini.api-key-file, GEMINI_API_KEY, or GEMINI_API_KEY_FILE)", err)
 	}
 
 	generator, err := gemini.NewGenerator(ctx, apiKey, cfg.Gemini.Model, cfg.Gemini.MaxRetries, logger)

--- a/hh-responder-example.yaml
+++ b/hh-responder-example.yaml
@@ -42,7 +42,9 @@ ai:
   provider: gemini
   minimum-fit-score: 0.6
   gemini:
-    # Prefer storing the key in GEMINI_API_KEY env var rather than this file.
+    # Prefer storing the key outside the config file. Provide either api-key-file
+    # (or GEMINI_API_KEY_FILE env var) or inline api-key / GEMINI_API_KEY env var.
+    # api-key-file: /path/to/gemini-api-key
     api-key: "${GEMINI_API_KEY}"
     model: gemini-2.5-pro
     # Number of attempts per request on transient or short quota errors (>=1).

--- a/internal/secrets/loader.go
+++ b/internal/secrets/loader.go
@@ -1,0 +1,49 @@
+package secrets
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Source describes how to load a secret value.
+type Source struct {
+	// Name is used in error messages to give more context about the secret.
+	Name string
+	// Value is an inline secret value provided via configuration or flags.
+	Value string
+	// File points to a file containing the secret value. When set it takes
+	// precedence over Value.
+	File string
+}
+
+// Load returns the resolved secret value from the provided source. When File is
+// set it takes precedence over Value. The returned secret is always trimmed. An
+// error is returned when neither File nor Value contain a usable secret.
+func Load(src Source) (string, error) {
+	name := strings.TrimSpace(src.Name)
+	if name == "" {
+		name = "secret"
+	}
+
+	if file := strings.TrimSpace(src.File); file != "" {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			return "", fmt.Errorf("reading %s from file %q: %w", name, file, err)
+		}
+
+		src.Value = string(data)
+		src.File = file
+	}
+
+	secret := strings.TrimSpace(src.Value)
+	if secret != "" {
+		return secret, nil
+	}
+
+	if src.File != "" {
+		return "", fmt.Errorf("%s file %q is empty", name, src.File)
+	}
+
+	return "", fmt.Errorf("%s is not configured", name)
+}


### PR DESCRIPTION
## Summary
- add a reusable secrets loader to centralize reading token values from files or inline config
- update hh token and gemini api key loading to use the shared helper and support ai.gemini.api-key-file plus related env vars
- refresh the sample config and README to document the new secret loading options

## Testing
- go test ./... -run TestNonExistent -count=0

------
https://chatgpt.com/codex/tasks/task_e_68dbce1e2cc8832f913ab5234cd43ee3