### PR TITLE
Add reason metadata to excluded vacancies

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -243,7 +243,7 @@ func manualApply(hh *headhunter.Client, logger *zap.Logger, config *Config, vaca
 				return err
 			}
 
-			excluded.Append(vacancies.ToExcluded())
+			excluded.Append(vacancies.ToExcluded(headhunter.ExcludeReasonManualApply))
 
 			if err = excluded.ToFile(excludeFile); err != nil {
 				return err

--- a/internal/filtering/ai_fit_filter.go
+++ b/internal/filtering/ai_fit_filter.go
@@ -136,7 +136,7 @@ func (f *aiFitFilter) evaluateVacanciesWithMatcher(ctx context.Context, resume m
 				zap.String("reason", assessment.Reason),
 			)
 
-			if err := f.appendToExcludeFile(detailed); err != nil {
+			if err := f.appendToExcludeFile(detailed, assessment.Reason); err != nil {
 				f.deps.Logger.Warn("failed to append vacancy to exclude file",
 					zap.String("vacancy_id", vacancy.ID),
 					zap.Error(err),
@@ -171,7 +171,7 @@ func (f *aiFitFilter) evaluateVacanciesWithMatcher(ctx context.Context, resume m
 	return assessments
 }
 
-func (f *aiFitFilter) appendToExcludeFile(vacancy *headhunter.Vacancy) error {
+func (f *aiFitFilter) appendToExcludeFile(vacancy *headhunter.Vacancy, reason string) error {
 	path := strings.TrimSpace(f.deps.ExcludeFile)
 	if path == "" {
 		return nil
@@ -182,7 +182,7 @@ func (f *aiFitFilter) appendToExcludeFile(vacancy *headhunter.Vacancy) error {
 		return fmt.Errorf("load excluded vacancies: %w", err)
 	}
 
-	toAppend := (&headhunter.Vacancies{Items: []*headhunter.Vacancy{vacancy}}).ToExcluded()
+	toAppend := (&headhunter.Vacancies{Items: []*headhunter.Vacancy{vacancy}}).ToExcluded(reason)
 	excluded.Append(toAppend)
 
 	if err := excluded.ToFile(path); err != nil {


### PR DESCRIPTION
## Summary
- add a reason field to excluded vacancy records with a fallback for AI rejections
- propagate AI assessment reasons and a manual apply marker when appending to the exclude file

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68de89e06d64832f8151c85d3bb8f50a