### PR TITLE
chore: bump codex workbench image to v0.42.0-dce3a2

### DIFF
--- a/deploy/develop/base/develop.yaml
+++ b/deploy/develop/base/develop.yaml
@@ -24,8 +24,8 @@ spec:
   # ---- Primary application container ----
   containers:
     - name: workbench
-      # Pinned to tag v0.42.0-532cf3 (digest sha256:1698708d26db5184d682debd27f45fe7961001db8262d0eebe1054b208fea835)
-      image: ghcr.io/spigell/codex-workbench@sha256:1698708d26db5184d682debd27f45fe7961001db8262d0eebe1054b208fea835
+      # Pinned to tag v0.42.0-dce3a2 (digest sha256:30ff0432e12ce60eecd8c875c0f1f00d4f76cacf9bcc775524c9c341762a803c)
+      image: ghcr.io/spigell/codex-workbench@sha256:30ff0432e12ce60eecd8c875c0f1f00d4f76cacf9bcc775524c9c341762a803c
       workingDir: /project
       command:
         - /bin/bash


### PR DESCRIPTION
## Summary
- update the Codex workbench deployment to use the v0.42.0-dce3a2 image digest

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68e10c7d35cc832fbe3e0d53a68e100e